### PR TITLE
修复歌单解析失败，修复解析文本失败，修复潜在bug

### DIFF
--- a/src/main/java/com/sqmusicplus/v3/controller/DownloadServiceController.java
+++ b/src/main/java/com/sqmusicplus/v3/controller/DownloadServiceController.java
@@ -134,27 +134,47 @@ public class DownloadServiceController {
     @SaCheckLogin
     @PostMapping("/downloadParserUrl")
     public AjaxResult downloadParserUrl(@RequestBody DownlaodParserUrl downlaodParserUrl) {
-        try {
-            List<Music> parser = urlMusicPlayListParser.parser(downlaodParserUrl);
-            if (parser == null){
-                return AjaxResult.error("解析失败 仅支持qq 酷我 酷狗概念 网易云");
-            }
-            ArrayList<DownloadInfo> downloadInfos = new ArrayList<>();
-            for (Music music : parser) {
-                SearchHanderAbstract plugHander = MusicUtils.getPlugHander(music.getPlugName(), searchHanderAbstractList);
-                DownloadInfo downloadInfo = plugHander.musicToDownloadInfo(music, null, false);
-                downloadInfos.add(downloadInfo);
-            }
-            Boolean add = downloadInfoService.add(downloadInfos);
-            if (add){
-                return AjaxResult.success("下载成功",downloadInfos);
-            }
-
-        } catch (Exception e) {
-            log.error("解析失败",e);
+        // Validate URL format first (quick check before going async)
+        String url = downlaodParserUrl.getUrl();
+        if (StringUtils.isBlank(url)) {
+            return AjaxResult.error("请输入要解析的URL");
+        }
+        if (!url.contains("y.qq.com") && !url.contains("www.kuwo.cn")
+                && !url.contains("music.163.com") && !url.contains("kugou.com")) {
             return AjaxResult.error("解析失败 仅支持qq 酷我 酷狗概念 网易云");
         }
-        return AjaxResult.error("下载失败");
+        // Run parsing and downloading asynchronously to avoid nginx proxy timeout
+        Thread thread = new Thread(() -> {
+            try {
+                List<Music> parser = urlMusicPlayListParser.parser(downlaodParserUrl);
+                if (parser == null || parser.isEmpty()) {
+                    log.warn("URL parser: no songs parsed from URL: {}", url);
+                    return;
+                }
+                ArrayList<DownloadInfo> downloadInfos = new ArrayList<>();
+                for (Music music : parser) {
+                    try {
+                        SearchHanderAbstract plugHander = MusicUtils.getPlugHander(music.getPlugName(), searchHanderAbstractList);
+                        DownloadInfo downloadInfo = plugHander.musicToDownloadInfo(music, null, false);
+                        downloadInfos.add(downloadInfo);
+                    } catch (Exception e) {
+                        log.error("URL parser: failed to create download info for song: {}, error: {}", music.getMusicName(), e.getMessage());
+                    }
+                }
+                if (!downloadInfos.isEmpty()) {
+                    Boolean add = downloadInfoService.add(downloadInfos);
+                    if (add) {
+                        log.info("URL parser: successfully added {} download tasks from URL: {}", downloadInfos.size(), url);
+                    }
+                } else {
+                    log.warn("URL parser: no download tasks created from URL: {}", url);
+                }
+            } catch (Exception e) {
+                log.error("URL parser: failed to parse URL: {}", url, e);
+            }
+        });
+        thread.start();
+        return AjaxResult.success("解析成功，稍后在下载处查看");
     }
 
 
@@ -199,14 +219,32 @@ public class DownloadServiceController {
                 if (parserEntities != null) {
                     ArrayList<DownloadInfo> downloadInfos = new ArrayList<>();
                     for (ParserEntity parserEntity : parserEntities) {
+                        // Skip entries that were not matched to any song
+                        if (parserEntity.getIsDetection() == null || !parserEntity.getIsDetection()) {
+                            log.warn("Text parser: song not matched, skipping: {} - {}", parserEntity.getSongName(), parserEntity.getArtistsName());
+                            continue;
+                        }
                         PlugSearchMusicResult plugSearchMusicResult = parserEntity.getPlugSearchMusicResult();
-                        SearchHanderAbstract plugHander = MusicUtils.getPlugHander(plugSearchMusicResult.getPlugName(), searchHanderAbstractList);
-                        DownloadInfo downloadInfo = plugHander.musicToDownloadInfo(plugSearchMusicResult, null, false);
-                        downloadInfos.add(downloadInfo);
+                        if (plugSearchMusicResult == null) {
+                            log.warn("Text parser: plugSearchMusicResult is null, skipping: {}", parserEntity.getSongName());
+                            continue;
+                        }
+                        try {
+                            SearchHanderAbstract plugHander = MusicUtils.getPlugHander(plugSearchMusicResult.getPlugName(), searchHanderAbstractList);
+                            DownloadInfo downloadInfo = plugHander.musicToDownloadInfo(plugSearchMusicResult, null, false);
+                            downloadInfos.add(downloadInfo);
+                        } catch (Exception e) {
+                            log.error("Text parser: failed to create download info for song: {}, error: {}", parserEntity.getSongName(), e.getMessage());
+                        }
                     }
-                    Boolean add = downloadInfoService.add(downloadInfos);
-                    if (add) {
-                        return;
+                    if (!downloadInfos.isEmpty()) {
+                        Boolean add = downloadInfoService.add(downloadInfos);
+                        if (add) {
+                            log.info("Text parser: successfully added {} download tasks", downloadInfos.size());
+                            return;
+                        }
+                    } else {
+                        log.warn("Text parser: no songs matched, nothing to download");
                     }
                 }
 //                return ;

--- a/src/main/java/com/sqmusicplus/v3/parser/TextMusicPlayListParser.java
+++ b/src/main/java/com/sqmusicplus/v3/parser/TextMusicPlayListParser.java
@@ -49,11 +49,12 @@ public class TextMusicPlayListParser {
     public List<ParserEntity> parser(String msg) throws IOException {
         String[] split = msg.split("\n");
         return Arrays.stream(split).map(m -> {
-            String[] sa = m.split("-");
+            // Split by first '-' only, to handle song names or artist names containing '-'
+            String[] sa = m.split("-", 2);
             try {
-                return new ParserEntity().setSongName(sa[0]).setArtistsName(sa[1]);
+                return new ParserEntity().setSongName(sa[0].trim()).setArtistsName(sa[1].trim());
             } catch (ArrayIndexOutOfBoundsException e) {
-                return  new ParserEntity().setSongName(m).setArtistsName("");
+                return  new ParserEntity().setSongName(m.trim()).setArtistsName("");
             }
         }).collect(Collectors.toList());
 
@@ -120,7 +121,7 @@ public class TextMusicPlayListParser {
                 if (record.getName().trim().equals(parserEntity.getSongName().trim())){
                     //匹配成功歌曲名称
                     if (StringUtils.isNotBlank(parserEntity.getArtistsName())){
-                        if (record.getArtistName().contains(parserEntity.getArtistsName().trim())){
+                        if (matchArtist(record.getArtistName(), parserEntity.getArtistsName().trim())){
                             parserEntity.setIsDetection(true);
                             parserEntity.setPlugSearchMusicResult(record);
                             parserEntity.setPlugName(plugSearchMusicResultPlugSearchResult.getPlugName());
@@ -139,6 +140,37 @@ public class TextMusicPlayListParser {
 
 
         }
+    }
+
+    /**
+     * Match artist name: support List<String> artistName from search result
+     * against user input which may contain multiple artists separated by / or ,
+     * Match succeeds if any artist in the search result matches any artist in user input
+     */
+    private static boolean matchArtist(List<String> recordArtists, String inputArtists) {
+        if (recordArtists == null || recordArtists.isEmpty()) {
+            return false;
+        }
+        // Split user input by common separators: / , 、
+        String[] inputParts = inputArtists.split("[/,、]");
+        for (String inputPart : inputParts) {
+            String trimmedInput = inputPart.trim();
+            if (StringUtils.isBlank(trimmedInput)) {
+                continue;
+            }
+            for (String recordArtist : recordArtists) {
+                if (recordArtist.trim().equalsIgnoreCase(trimmedInput)) {
+                    return true;
+                }
+            }
+        }
+        // Also try matching the whole input string against any artist (fallback)
+        for (String recordArtist : recordArtists) {
+            if (recordArtist.trim().equalsIgnoreCase(inputArtists)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/sqmusicplus/v3/parser/UrlMusicPlayListParser.java
+++ b/src/main/java/com/sqmusicplus/v3/parser/UrlMusicPlayListParser.java
@@ -57,6 +57,11 @@ public class UrlMusicPlayListParser {
 
     public List<Music> parser(DownlaodParserUrl downlaodParserUrl) throws IOException {
         String url = downlaodParserUrl.getUrl();
+        // Pre-process: convert hash route format (e.g. music.163.com/#/playlist?id=xxx) to standard path format
+        if (url.contains("#/")) {
+            url = url.replace("#/", "");
+            log.info("URL hash route detected, converted to: {}", url);
+        }
         //找出url所属的平台
         if (url.contains("y.qq.com")) {
             //获取url的302来判断是那种类型
@@ -367,7 +372,17 @@ public class UrlMusicPlayListParser {
             throw new RuntimeException(e);
         }
         String query = uri.getQuery();
+        // Fallback: if query is null, try to extract params from fragment (e.g. #/playlist?id=xxx)
+        if (query == null) {
+            String fragment = uri.getFragment();
+            if (fragment != null && fragment.contains("?")) {
+                query = fragment.substring(fragment.indexOf("?") + 1);
+            }
+        }
         Map<String, String> params = new HashMap<>();
+        if (query == null || query.isEmpty()) {
+            return params;
+        }
         for (String param : query.split("&")) {
             String[] pair = param.split("=");
             params.put(pair[0], pair.length > 1 ? pair[1] : null);

--- a/src/main/java/com/sqmusicplus/v3/plug/base/hander/SearchHanderAbstract.java
+++ b/src/main/java/com/sqmusicplus/v3/plug/base/hander/SearchHanderAbstract.java
@@ -298,8 +298,11 @@ public abstract class SearchHanderAbstract implements SearchHander, Serializable
         if (brType==null){
             brType = MusicUtils.getMaxBr(bits);
         }
-        String bitsStr = bits.stream().map(plugBrType -> plugBrType.getBit().toString()).collect(Collectors.joining(","));
-        String plugBrTypes = bits.stream().map(plugBrType -> plugBrType.getId()).collect(Collectors.joining(","));
+        if (brType == null) {
+            throw new RuntimeException("No available bit rate for song: " + music.getMusicName());
+        }
+        String bitsStr = (bits != null && !bits.isEmpty()) ? bits.stream().map(plugBrType -> plugBrType.getBit().toString()).collect(Collectors.joining(",")) : "";
+        String plugBrTypes = (bits != null && !bits.isEmpty()) ? bits.stream().map(plugBrType -> plugBrType.getId()).collect(Collectors.joining(",")) : "";
 
         return new DownloadInfo()
                 .setDownloadGid(music.getId())
@@ -327,8 +330,11 @@ public abstract class SearchHanderAbstract implements SearchHander, Serializable
         if (brType==null){
             brType = MusicUtils.getMaxBr(bits);
         }
-        String bitsStr = bits.stream().map(plugBrType -> plugBrType.getBit().toString()).collect(Collectors.joining(","));
-        String plugBrTypes = bits.stream().map(plugBrType -> plugBrType.getId()).collect(Collectors.joining(","));
+        if (brType == null) {
+            throw new RuntimeException("No available bit rate for song: " + music.getName());
+        }
+        String bitsStr = (bits != null && !bits.isEmpty()) ? bits.stream().map(plugBrType -> plugBrType.getBit().toString()).collect(Collectors.joining(",")) : "";
+        String plugBrTypes = (bits != null && !bits.isEmpty()) ? bits.stream().map(plugBrType -> plugBrType.getId()).collect(Collectors.joining(",")) : "";
         String jsonString ="";
         try {
             jsonString = music.getDataInfo().toJSONString();

--- a/src/main/java/com/sqmusicplus/v3/utils/MusicUtils.java
+++ b/src/main/java/com/sqmusicplus/v3/utils/MusicUtils.java
@@ -173,6 +173,9 @@ public class MusicUtils {
      * @return
      */
     public static PlugBrType getMaxBr(List<PlugBrType> brTypes) {
+        if (brTypes == null || brTypes.isEmpty()) {
+            return null;
+        }
         return brTypes.stream().max(Comparator.comparing(PlugBrType::getBit)).get();
     }
 


### PR DESCRIPTION
## 问题
1. 解析 QQ 音乐等歌单 URL 时，由于逐首查询歌曲详情耗时过长，超过 nginx 的 
   proxy_read_timeout（60s），导致前端收到 502，表现为"解析没反应"
2. 文本解析提交后提示成功，但下载界面无记录('-' '/'分隔符的处理)
3. 网易云歌单 URL 解析匹配正则存在问题（url中的#字符）

## 修复内容
- 将 `downloadParserUrl` 和 `downloadParserText` 接口改为异步处理：
  先做快速校验并立即返回响应，后台线程异步完成歌曲查询和下载任务添加
- 修复网易云歌单 URL 正则匹配，支持更多 URL 格式
- 修复文本解析逻辑中的问题

## 修改文件
- `DownloadServiceController.java` - 异步化解析接口
- `UrlMusicPlayListParser.java` - 修复 URL 正则匹配
- `TextMusicPlayListParser.java` - 修复文本解析逻辑