### PR TITLE
fix: skip unplayable songs instead of aborting netease playlist parsing

### DIFF
--- a/src/main/java/com/sqmusicplus/v3/plug/netease/hander/NeteaseHander.java
+++ b/src/main/java/com/sqmusicplus/v3/plug/netease/hander/NeteaseHander.java
@@ -708,41 +708,49 @@ public class NeteaseHander extends SearchHanderAbstract {
         }
         //处理歌曲
         songs.forEach(songsInfoDTO -> {
-            PlaylistTrackAllResult.SongsDTO songsDTO = songsInfoDTO;
-            PlaylistTrackAllResult.SongsDTO.HDTO h = songsDTO.getH();
-            PlaylistTrackAllResult.SongsDTO.MDTO m = songsDTO.getM();
-            PlaylistTrackAllResult.SongsDTO.LDTO l = songsDTO.getL();
-            PlaylistTrackAllResult.SongsDTO.SqDTO sq = songsDTO.getSq();
-            PlaylistTrackAllResult.SongsDTO.SqDTO hr = songsDTO.getHr();
-            ArrayList<PlugBrType> plugBrTypes = new ArrayList<>();
-            if (h!=null&&h.getBr()!=null){
-                plugBrTypes.add(PlugBrType.NETEASE_MP3_320);
+            try {
+                PlaylistTrackAllResult.SongsDTO songsDTO = songsInfoDTO;
+                PlaylistTrackAllResult.SongsDTO.HDTO h = songsDTO.getH();
+                PlaylistTrackAllResult.SongsDTO.MDTO m = songsDTO.getM();
+                PlaylistTrackAllResult.SongsDTO.LDTO l = songsDTO.getL();
+                PlaylistTrackAllResult.SongsDTO.SqDTO sq = songsDTO.getSq();
+                PlaylistTrackAllResult.SongsDTO.SqDTO hr = songsDTO.getHr();
+                ArrayList<PlugBrType> plugBrTypes = new ArrayList<>();
+                if (h!=null&&h.getBr()!=null){
+                    plugBrTypes.add(PlugBrType.NETEASE_MP3_320);
+                }
+                if (m!=null&&m.getBr()!=null){
+                    plugBrTypes.add(PlugBrType.NETEASE_MP3_192);
+                }
+                if (l!=null&&l.getBr()!=null){
+                    plugBrTypes.add(PlugBrType.NETEASE_MP3_128);
+                }
+                if (sq!=null&&sq.getBr()!=null){
+                    plugBrTypes.add(PlugBrType.NETEASE_FLAC_2000);
+                }
+                if (hr!=null&&hr.getBr()!=null){
+                    plugBrTypes.add(PlugBrType.NETEASE_FLAC_3000);
+                }
+                Music music = new Music();
+                music.setId(songsInfoDTO.getId().toString())
+                        .setMusicName(songsInfoDTO.getName())
+                        .setMusicDuration(songsInfoDTO.getDt())
+                        .setMusicAlbum(songsInfoDTO.getAl().getName())
+                        .setMusicArtists(songsInfoDTO.getAr().stream().map(e -> e.getName()).collect(Collectors.toList()))
+                        .setMusicImage(songsInfoDTO.getAl().getPicUrl())
+                        .setAlbumId(songsInfoDTO.getAl().getId().toString())
+                        .setPlugName(getPlugName())
+                        .setDataInfo(JSONObject.parseObject(JSONObject.toJSONString(songsInfoDTO)))
+                        .setArtistsIds(songsInfoDTO.getAr().stream().map(e -> e.getId().toString()).collect(Collectors.toList()))
+                                .setBits(plugBrTypes);
+                musics.add(music);
+            } catch (Exception e) {
+                //单首歌曲信息不完整（如无音源、缺少专辑或歌手信息）时跳过该曲，避免整个歌单解析中断
+                log.warn("网易歌单解析跳过歌曲 id={} name={}，原因：{}",
+                        songsInfoDTO != null ? songsInfoDTO.getId() : null,
+                        songsInfoDTO != null ? songsInfoDTO.getName() : null,
+                        e.getMessage());
             }
-            if (m!=null&&m.getBr()!=null){
-                plugBrTypes.add(PlugBrType.NETEASE_MP3_192);
-            }
-            if (l!=null&&l.getBr()!=null){
-                plugBrTypes.add(PlugBrType.NETEASE_MP3_128);
-            }
-            if (sq!=null&&sq.getBr()!=null){
-                plugBrTypes.add(PlugBrType.NETEASE_FLAC_2000);
-            }
-            if (hr!=null&&hr.getBr()!=null){
-                plugBrTypes.add(PlugBrType.NETEASE_FLAC_3000);
-            }
-            Music music = new Music();
-            music.setId(songsInfoDTO.getId().toString())
-                    .setMusicName(songsInfoDTO.getName())
-                    .setMusicDuration(songsInfoDTO.getDt())
-                    .setMusicAlbum(songsInfoDTO.getAl().getName())
-                    .setMusicArtists(songsInfoDTO.getAr().stream().map(e -> e.getName()).collect(Collectors.toList()))
-                    .setMusicImage(songsInfoDTO.getAl().getPicUrl())
-                    .setAlbumId(songsInfoDTO.getAl().getId().toString())
-                    .setPlugName(getPlugName())
-                    .setDataInfo(JSONObject.parseObject(JSONObject.toJSONString(songsInfoDTO)))
-                    .setArtistsIds(songsInfoDTO.getAr().stream().map(e -> e.getId().toString()).collect(Collectors.toList()))
-                            .setBits(plugBrTypes);
-            musics.add(music);
         });
         return musics;
     }


### PR DESCRIPTION
## Summary
Make Netease playlist parsing resilient to individual unplayable songs. In `NeteaseHander.getPlayList`, the per-song mapping body is now wrapped in a try/catch so a single song with no audio source or incomplete metadata is logged and skipped instead of aborting the whole playlist.

## Why this matters
Ref #113. The reporter has a 1200+ song "我喜欢的音乐" playlist where parsing stops at one specific song with no playable source (租购 - 薛之谦) and every song after it is dropped.

Root cause: in `src/main/java/com/sqmusicplus/v3/plug/netease/hander/NeteaseHander.java:710` the `songs.forEach(...)` lambda dereferences `songsInfoDTO.getAl().getName()`, `getAl().getId()`, and `getAr().stream()...` (lines 737-743) without null checks. When a song has a null album or null/empty artist list, the resulting NullPointerException propagates out of `forEach` and aborts mapping of all remaining songs, so they never make it into the returned list.

The fix wraps the mapping body in try/catch, logs a warning with the song id and name via the existing slf4j `log`, and continues to the next song. Well-formed songs are still mapped one-to-one; only the malformed ones are skipped. This matches the per-entry resilience already used in `TextMusicPlayListParser.parserParserEntity`, which wraps each entry in try/catch and continues.

## Testing
No local JDK was available to run the Maven build, so CI will validate compilation. The change is scoped to a single method, uses only already-imported types and the existing `@Slf4j` `log`, and is a pure wrap of the existing logic in try/catch (verified by diff: indentation shift plus the try/catch frame, no logic change inside).

Behavior:
- Happy path: every song has full metadata, so the list maps one-to-one with no change.
- Edge case: a middle song with a null album or empty artist list is now skipped with a logged warning, and all remaining songs are still returned.
- Error path: the exception from a single malformed song no longer escapes `getPlayList`, so callers receive the full remaining list rather than an aborted partial result.

This addresses the no-source-abort half of the issue. The separate intermittent network-timeout-on-re-add symptom is not reproducible from static analysis and needs the reporter's retest of the latest build.

Fixes #113
