### PR TITLE
fix(netease): 为所有 POST 接口添加时间戳绕过上游代理缓存

### DIFF
--- a/src/main/java/com/sqmusicplus/v3/plug/netease/hander/SQNeteaseCloudMusicInfo.java
+++ b/src/main/java/com/sqmusicplus/v3/plug/netease/hander/SQNeteaseCloudMusicInfo.java
@@ -115,27 +115,31 @@ public class SQNeteaseCloudMusicInfo {
     }
 
     public JSONObject songMusicDetail(JSONObject parameter) {
-        String url = "/song/music/detail";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/song/music/detail?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
 
 
     public JSONObject songDownloadUrl(JSONObject parameter) {
-        String url = "/song/download/url";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/song/download/url?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
 
     }
 
 
     public JSONObject searchSuggest(JSONObject parameter) {
-        String url = "/search/suggest";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/search/suggest?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
 
 
 
     public JSONObject cloudsearch(JSONObject parameter) {
-        String url = "/cloudsearch";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/cloudsearch?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
 
@@ -148,36 +152,42 @@ public class SQNeteaseCloudMusicInfo {
     }
 
     public JSONObject artistDetail(JSONObject parameter) {
-        String url = "/artist/detail";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/artist/detail?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
 
 
     public JSONObject album(JSONObject parameter) {
-        String url = "/album";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/album?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
 
 
 
     public JSONObject lyric(JSONObject parameter) {
-        String url = "/lyric";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/lyric?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
 
 
     public JSONObject artistAlbum(JSONObject parameter) {
-        String url = "/artist/album";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/artist/album?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
 
     public JSONObject playlistDetail(JSONObject parameter) {
-        String url = "/playlist/detail";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/playlist/detail?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
 
     public JSONObject playlistTrackAll(JSONObject parameter) {
-        String url = "/playlist/track/all";
+        // 加时间戳绕过代理缓存，确保每次拿到真实数据（与 songDetail 一致）
+        String url = "/playlist/track/all?_t=" + System.currentTimeMillis();
         return DownloadUtils.postCookieToJsonObject(baseUrl + url, parameter, cookie,header);
     }
     public JSONObject innerVersion(){


### PR DESCRIPTION
## 问题

sqmusic 3.1.20 的网易云插件存在数据串线问题：
- `downloadAlbum` / `albumInfoById` / `ArtistAlbumById` 连续查询不同专辑/艺人时返回上一次的结果
- 批量下载时同一张专辑被重复写入（如 14 首歌 x10 次重复任务）

## 根因

上游网易云 API 代理（NeteaseCloudMusicApi 类实现）的缓存 key 不含请求体：
- POST `/album` {"id":"438054"} 返回 AHDN 正确
- 紧接着 POST `/album` {"id":"438023"} 仍返回 AHDN（缓存命中）
- URL 加 `?_t=<毫秒时间戳>` 后立即返回正确专辑

源码中 `SQNeteaseCloudMusicInfo.songDetail` 已通过时间戳绕过（见注释"加时间戳绕过代理缓存"），但其余 10 个 POST 接口全部未处理。

## 修复

`SQNeteaseCloudMusicInfo.java`：全部 10 个 POST 接口（songMusicDetail / songDownloadUrl / searchSuggest / cloudsearch / artistDetail / album / lyric / artistAlbum / playlistDetail / playlistTrackAll）URL 统一追加 `?_t=System.currentTimeMillis()`，与 songDetail 一致。

## 验证

已在生产环境（3.1.20）部署验证：
- albumInfoById 连续 5 张不同专辑全部返回正确
- downloadAlbum 批量 7 张专辑全部正确写入，无重复无串数据